### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ options: {
 ```
 You can generate nested namespaces based on the file system paths of your templates by providing a function. The function will be called with one argument (the template filepath). The function must return a dot notation based on the filepath.
 
+-The last array entry name derives from the `processName` option. The constructed final notation is `<options.global>[<namespace>][<namespace>]...[<processName>]`
+
 Example:
 
 ```js
@@ -110,6 +112,9 @@ options: {
     var names = filename.replace(/modules\/(.*)(\/\w+\.hbs)/, '$1');
     return names.split('/').join('.');
   },
+  processName: function(filename) {
+    return filename = filename.substring(filename.lastIndexOf('/') + 1, filename.lastIndexOf('.'));
+  }
   demo: {
   	files: {
     	'ns_nested_tmpls.js' : [ 'modules/**/*.html']


### PR DESCRIPTION
The `processName` option is missing from the configuration. Pretty easy to spot when someone checks the source code but why not make life easier by just adding it to the readme.

p.s. writing documentation is none of my strong skills, feel free to change it. But I think the processName option should be mentioned in the readme.

cheerz
